### PR TITLE
SAAS-447 Reset dropdown active item on close

### DIFF
--- a/packages/platform-core/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/platform-core/src/components/Dropdown/Dropdown.styles.ts
@@ -6,6 +6,9 @@ export const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const { spacing, colors, border } = theme;
 
   return {
+    dropdown: css`
+      z-index: 1;
+    `,
     dropdownMenu: css`
       display: flex;
       flex-direction: column;

--- a/packages/platform-core/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/platform-core/src/components/Dropdown/Dropdown.test.tsx
@@ -16,6 +16,22 @@ const Toggle = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => 
 const DATA_QA_MENU='dropdown-menu-menu';
 const DATA_QA_TOGGLE='dropdown-menu-toggle';
 
+const openMenu = async () => {
+  const toggle = container.querySelector(dataQa(DATA_QA_TOGGLE));
+
+  await act(async () => {
+    fireEvent.click(toggle!);
+  });
+};
+
+const clickMenuItem = async (item: string) => {
+  await act(async () => {
+    const menuItem = container.querySelector(dataQa(item));
+
+    fireEvent.click(menuItem!);
+  });
+};
+
 describe('Dropdown ::', () => {
   beforeEach(() => {
     container = document.createElement('div');
@@ -128,5 +144,39 @@ describe('Dropdown ::', () => {
     });
 
     expect(menuAction).toBeCalledTimes(1);
+  });
+
+  test('keeps menu item active on close', async () => {
+    act(() => {
+      render(<Dropdown toggle={Toggle} keepActiveOnClose>
+        <div data-qa="menu-item" onClick={jest.fn()}>root</div>
+        <a href="/test">test</a>
+      </Dropdown>, container);
+    });
+
+    await openMenu();
+    await clickMenuItem('menu-item');
+    await openMenu();
+
+    const menuItem = container.querySelector(dataQa('menu-item'));
+
+    expect(menuItem?.className.includes('active')).toBeTruthy();
+  });
+
+  test('doesnt keep menu item active on close', async () => {
+    act(() => {
+      render(<Dropdown toggle={Toggle}>
+        <div data-qa="menu-item" onClick={jest.fn()}>root</div>
+        <a href="/test">test</a>
+      </Dropdown>, container);
+    });
+
+    await openMenu();
+    await clickMenuItem('menu-item');
+    await openMenu();
+
+    const menuItem = container.querySelector(dataQa('menu-item'));
+
+    expect(menuItem?.className.includes('active')).toBeFalsy();
   });
 });

--- a/packages/platform-core/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/platform-core/src/components/Dropdown/Dropdown.test.tsx
@@ -146,23 +146,6 @@ describe('Dropdown ::', () => {
     expect(menuAction).toBeCalledTimes(1);
   });
 
-  test('keeps menu item active on close', async () => {
-    act(() => {
-      render(<Dropdown toggle={Toggle} keepActiveOnClose>
-        <div data-qa="menu-item" onClick={jest.fn()}>root</div>
-        <a href="/test">test</a>
-      </Dropdown>, container);
-    });
-
-    await openMenu();
-    await clickMenuItem('menu-item');
-    await openMenu();
-
-    const menuItem = container.querySelector(dataQa('menu-item'));
-
-    expect(menuItem?.className.includes('active')).toBeTruthy();
-  });
-
   test('doesnt keep menu item active on close', async () => {
     act(() => {
       render(<Dropdown toggle={Toggle}>

--- a/packages/platform-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/platform-core/src/components/Dropdown/Dropdown.tsx
@@ -25,14 +25,12 @@ interface DropdownProps {
   >;
   children: Array<React.ReactElement> | React.ReactElement;
   className?: string;
-  keepActiveOnClose?: boolean;
 }
 
 export const Dropdown: FC<DropdownProps> = React.memo(({
   className,
   children,
   toggle: Toggle,
-  keepActiveOnClose = false,
 }) => {
   const theme = useTheme();
   const styles = useMemo(() => getStyles(theme), [theme]);
@@ -135,7 +133,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(({
       // setActiveIndex(-1);
 
       // on close reset index
-      if (!keepActiveOnClose && !visible) {
+      if (!visible) {
         setActiveIndex(-1);
       }
     };

--- a/packages/platform-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/platform-core/src/components/Dropdown/Dropdown.tsx
@@ -25,12 +25,14 @@ interface DropdownProps {
   >;
   children: Array<React.ReactElement> | React.ReactElement;
   className?: string;
+  keepActiveOnClose?: boolean;
 }
 
 export const Dropdown: FC<DropdownProps> = React.memo(({
   className,
   children,
   toggle: Toggle,
+  keepActiveOnClose = false,
 }) => {
   const theme = useTheme();
   const styles = useMemo(() => getStyles(theme), [theme]);
@@ -131,6 +133,11 @@ export const Dropdown: FC<DropdownProps> = React.memo(({
       // UX: don't reset the index when tearing down the children
       // TODO: evaluate pros and cons
       // setActiveIndex(-1);
+
+      // on close reset index
+      if (!keepActiveOnClose && !visible) {
+        setActiveIndex(-1);
+      }
     };
   }, [activeIndex, children, size, visible]);
 
@@ -141,6 +148,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(({
       <div
         ref={popperRef}
         style={popperStyles.popper}
+        className={styles.dropdown}
         {...popperAttributes.popper}
         data-qa="dropdown-menu-container"
       >


### PR DESCRIPTION
Reset active item when the dropdown closes (so it doesn't show as active when it opens again).

Also adds a z-index to fix cases where the dropdown gets behind other elements.