### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@atymchuk @nicolalamacchia


### PR DESCRIPTION
We remove CODEOWNERS to be able to leverage the `pmm-review-fe` group.